### PR TITLE
Fixes for mac build

### DIFF
--- a/src/ofbx.cpp
+++ b/src/ofbx.cpp
@@ -3,9 +3,20 @@
 #include <cassert>
 #include <cmath>
 #include <memory>
+#include <string>
 #include <unordered_map>
 #include <vector>
 
+#ifdef OFBX_DEFINE_MAKE_UNIQUE
+namespace std
+{
+	template<typename T, typename... Args>
+	std::unique_ptr<T> make_unique(Args&&... args)
+	{
+		return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
+	}
+}
+#endif
 
 namespace ofbx
 {
@@ -246,8 +257,8 @@ bool DataView::operator==(const char* rhs) const
 
 
 struct Property;
-template <typename T> bool parseBinaryArrayRaw(const Property& property, T* out, int max_size);
-template <typename T> bool parseBinaryArray(Property& property, std::vector<T>* out);
+template <typename T> static bool parseBinaryArrayRaw(const Property& property, T* out, int max_size);
+template <typename T> static bool parseBinaryArray(Property& property, std::vector<T>* out);
 
 
 struct Property : IElementProperty
@@ -857,8 +868,8 @@ struct ClusterImpl : Cluster
 	virtual int getIndicesCount() const override { return (int)indices.size(); }
 	const double* getWeights() const override { return &weights[0]; }
 	int getWeightsCount() const override { return (int)weights.size(); }
-	Matrix getTransformMatrix() const { return transform_matrix; }
-	Matrix getTransformLinkMatrix() const { return transform_link_matrix; }
+	Matrix getTransformMatrix() const override { return transform_matrix; }
+	Matrix getTransformLinkMatrix() const override { return transform_link_matrix; }
 	Object* getLink() const override { return link; }
 
 
@@ -948,7 +959,7 @@ struct AnimationStackImpl : AnimationStack
 	}
 
 
-	const AnimationLayer* getLayer(int index) const
+	const AnimationLayer* getLayer(int index) const override
 	{
 		assert(index == 0);
 		return resolveObjectLink<AnimationLayer>(index);
@@ -1055,7 +1066,7 @@ struct Scene : IScene
 	};
 
 
-	int getAnimationStackCount() const { return (int)m_animation_stacks.size(); }
+	int getAnimationStackCount() const override { return (int)m_animation_stacks.size(); }
 	int getMeshCount() const override { return (int)m_meshes.size(); }
 
 


### PR DESCRIPTION
This PR contains the fixes I needed to make to compile the program on a mac.
From most to least important:
- Add missing `#include <string>`
- Add `static` to header declarations for static functions
- Add optional define `OFBX_DEFINE_MAKE_UNIQUE` which defines `std::make_unique`
- Add `override` declarations where they are missing