### PR TITLE
Fix segfault on files with unused vertices

### DIFF
--- a/src/ofbx.cpp
+++ b/src/ofbx.cpp
@@ -1210,7 +1210,7 @@ struct ClusterImpl : Cluster
 			int old_idx = ir[i];
 			double w = wr[i];
 			GeometryImpl::NewVertex* n = &geom->to_new_vertices[old_idx];
-      if (n->index == -1) continue; // skip vertices which aren't indexed.
+			if (n->index == -1) continue; // skip vertices which aren't indexed.
 			while (n)
 			{
 				indices.push_back(n->index);

--- a/src/ofbx.cpp
+++ b/src/ofbx.cpp
@@ -1210,6 +1210,7 @@ struct ClusterImpl : Cluster
 			int old_idx = ir[i];
 			double w = wr[i];
 			GeometryImpl::NewVertex* n = &geom->to_new_vertices[old_idx];
+      if (n->index == -1) continue; // skip vertices which aren't indexed.
 			while (n)
 			{
 				indices.push_back(n->index);
@@ -2049,7 +2050,7 @@ static OptionalError<Object*> parseGeometry(const Scene& scene, const Element& e
 		geom->vertices[i] = vertices[geom->to_old_vertices[i]];
 	}
 
-	geom->to_new_vertices.resize(geom->to_old_vertices.size());
+	geom->to_new_vertices.resize(vertices.size()); // some vertices can be unused, so this isn't necessarily the same size as to_old_vertices.
 	const int* to_old_vertices = geom->to_old_vertices.empty() ? nullptr : &geom->to_old_vertices[0];
 	for (int i = 0, c = (int)geom->to_old_vertices.size(); i < c; ++i)
 	{

--- a/src/ofbx.h
+++ b/src/ofbx.h
@@ -111,6 +111,17 @@ struct IElement
 };
 
 
+enum class RotationOrder {
+	EULER_XYZ,
+	EULER_XZY,
+	EULER_YZX,
+	EULER_YXZ,
+	EULER_ZXY,
+	EULER_ZYX,
+    SPHERIC_XYZ // Currently unsupported. Treated as EULER_XYZ.
+};
+
+
 struct AnimationCurveNode;
 struct AnimationLayer;
 struct Scene;
@@ -148,6 +159,7 @@ struct Object
 	Object* resolveObjectLinkReverse(Type type) const;
 	Object* getParent() const;
 
+    RotationOrder getRotationOrder() const;
 	Vec3 getRotationOffset() const;
 	Vec3 getRotationPivot() const;
 	Vec3 getPostRotation() const;


### PR DESCRIPTION
One of the files I'm testing with has a mesh in which most of the vertices are not indexed.  This caused a segfault when OpenFBX tries to reverse its index permutation for skinning.
It's been fixed by enlarging the reverse permutation to contain mappings for all of the original vertices, regardless of how many were actually used.  The skinning lookup then checks for unmapped vertices and ignores their skinning weights.
Here's the (zipped) file for reference:
[UnusedVertices.zip](https://github.com/nem0/OpenFBX/files/1288587/UnusedVertices.zip)