### PR TITLE
Fix inverted post rotation

### DIFF
--- a/src/ofbx.cpp
+++ b/src/ofbx.cpp
@@ -1210,7 +1210,7 @@ struct ClusterImpl : Cluster
 			int old_idx = ir[i];
 			double w = wr[i];
 			GeometryImpl::NewVertex* n = &geom->to_new_vertices[old_idx];
-      if (n->index == -1) continue; // skip vertices which aren't indexed.
+			if (n->index == -1) continue; // skip vertices which aren't indexed.
 			while (n)
 			{
 				indices.push_back(n->index);

--- a/src/ofbx.cpp
+++ b/src/ofbx.cpp
@@ -2609,7 +2609,7 @@ Matrix Object::evalLocal(const Vec3& translation, const Vec3& rotation) const
 
 	Matrix r = getRotationMatrix(rotation, rotation_order);
 	Matrix r_pre = getRotationMatrix(getPreRotation(), RotationOrder::EULER_XYZ);
-	Matrix r_post_inv = getRotationMatrix(getPostRotation(), RotationOrder::EULER_XYZ);
+	Matrix r_post_inv = getRotationMatrix(-getPostRotation(), RotationOrder::EULER_ZYX);
 
 	Matrix r_off = makeIdentity();
 	setTranslation(getRotationOffset(), &r_off);

--- a/src/ofbx.cpp
+++ b/src/ofbx.cpp
@@ -1210,6 +1210,7 @@ struct ClusterImpl : Cluster
 			int old_idx = ir[i];
 			double w = wr[i];
 			GeometryImpl::NewVertex* n = &geom->to_new_vertices[old_idx];
+      if (n->index == -1) continue; // skip vertices which aren't indexed.
 			while (n)
 			{
 				indices.push_back(n->index);
@@ -2049,7 +2050,7 @@ static OptionalError<Object*> parseGeometry(const Scene& scene, const Element& e
 		geom->vertices[i] = vertices[geom->to_old_vertices[i]];
 	}
 
-	geom->to_new_vertices.resize(geom->to_old_vertices.size());
+	geom->to_new_vertices.resize(vertices.size()); // some vertices can be unused, so this isn't necessarily the same size as to_old_vertices.
 	const int* to_old_vertices = geom->to_old_vertices.empty() ? nullptr : &geom->to_old_vertices[0];
 	for (int i = 0, c = (int)geom->to_old_vertices.size(); i < c; ++i)
 	{

--- a/src/ofbx.h
+++ b/src/ofbx.h
@@ -111,6 +111,17 @@ struct IElement
 };
 
 
+enum class RotationOrder {
+	EULER_XYZ,
+	EULER_XZY,
+	EULER_YZX,
+	EULER_YXZ,
+	EULER_ZXY,
+	EULER_ZYX,
+    SPHERIC_XYZ // Currently unsupported. Treated as EULER_XYZ.
+};
+
+
 struct AnimationCurveNode;
 struct AnimationLayer;
 struct Scene;
@@ -148,6 +159,7 @@ struct Object
 	Object* resolveObjectLinkReverse(Type type) const;
 	Object* getParent() const;
 
+    RotationOrder getRotationOrder() const;
 	Vec3 getRotationOffset() const;
 	Vec3 getRotationPivot() const;
 	Vec3 getPostRotation() const;


### PR DESCRIPTION
When calculating node transforms, the post rotation wasn't inverted before.  This probably wasn't noticed because most nodes don't have a post rotation.