### PR TITLE
Remove failing assertions.

### DIFF
--- a/src/ofbx.cpp
+++ b/src/ofbx.cpp
@@ -1638,8 +1638,6 @@ template <typename T> static bool parseArrayRaw(const Property& property, T* out
 {
 	if (property.value.is_binary)
 	{
-		assert(out);
-
 		int elem_size = 1;
 		switch (property.type)
 		{
@@ -1905,7 +1903,6 @@ static void splat(std::vector<T>* out,
 	const std::vector<int>& to_old_vertices)
 {
 	assert(out);
-	assert(!data.empty());
 
 	if (mapping == GeometryImpl::BY_POLYGON_VERTEX)
 	{

--- a/src/ofbx.cpp
+++ b/src/ofbx.cpp
@@ -1173,8 +1173,8 @@ struct ClusterImpl : Cluster
 	int getIndicesCount() const override { return (int)indices.size(); }
 	const double* getWeights() const override { return &weights[0]; }
 	int getWeightsCount() const override { return (int)weights.size(); }
-	Matrix getTransformMatrix() const { return transform_matrix; }
-	Matrix getTransformLinkMatrix() const { return transform_link_matrix; }
+	Matrix getTransformMatrix() const override { return transform_matrix; }
+	Matrix getTransformLinkMatrix() const override { return transform_link_matrix; }
 	Object* getLink() const override { return link; }
 
 
@@ -1265,7 +1265,7 @@ struct AnimationStackImpl : AnimationStack
 	}
 
 
-	const AnimationLayer* getLayer(int index) const
+	const AnimationLayer* getLayer(int index) const override
 	{
 		assert(index == 0);
 		return resolveObjectLink<AnimationLayer>(index);
@@ -1372,7 +1372,7 @@ struct Scene : IScene
 	};
 
 
-	int getAnimationStackCount() const { return (int)m_animation_stacks.size(); }
+	int getAnimationStackCount() const override { return (int)m_animation_stacks.size(); }
 	int getMeshCount() const override { return (int)m_meshes.size(); }
 
 

--- a/src/ofbx.cpp
+++ b/src/ofbx.cpp
@@ -304,8 +304,8 @@ bool DataView::operator==(const char* rhs) const
 
 
 struct Property;
-template <typename T> bool parseArrayRaw(const Property& property, T* out, int max_size);
-template <typename T> bool parseBinaryArray(const Property& property, std::vector<T>* out);
+template <typename T> static bool parseArrayRaw(const Property& property, T* out, int max_size);
+template <typename T> static bool parseBinaryArray(const Property& property, std::vector<T>* out);
 
 
 struct Property : IElementProperty


### PR DESCRIPTION
These assertions fall on [cat.fbx](https://github.com/nrz/ylikuutio/blob/master/res/objects/www.blendswap.com/86110_rigged_and_animated_cat/cat.fbx) created by exporting [cat.blend file of Rigged and animated cat](https://www.blendswap.com/blends/view/86110), using Blender.