### PR TITLE
Added missing include and made it c++11 compatible

### DIFF
--- a/src/ofbx.cpp
+++ b/src/ofbx.cpp
@@ -6,6 +6,7 @@
 #include <memory>
 #include <unordered_map>
 #include <vector>
+#include <string>
 
 
 namespace ofbx
@@ -511,7 +512,7 @@ static OptionalError<Property*> readProperty(Cursor* cursor)
 {
 	if (cursor->current == cursor->end) return Error("Reading past the end");
 
-	std::unique_ptr<Property> prop = std::make_unique<Property>();
+	std::unique_ptr<Property> prop(new Property());
 	prop->next = nullptr;
 	prop->type = *cursor->current;
 	++cursor->current;
@@ -716,7 +717,7 @@ static DataView readTextToken(Cursor* cursor)
 
 static OptionalError<Property*> readTextProperty(Cursor* cursor)
 {
-	std::unique_ptr<Property> prop = std::make_unique<Property>();
+	std::unique_ptr<Property> prop(new Property());
 	prop->value.is_binary = false;
 	prop->next = nullptr;
 	if (*cursor->current == '"')
@@ -1583,7 +1584,7 @@ template <typename T> static OptionalError<Object*> parse(const Scene& scene, co
 
 static OptionalError<Object*> parseCluster(const Scene& scene, const Element& element)
 {
-	std::unique_ptr<ClusterImpl> obj = std::make_unique<ClusterImpl>(scene, element);
+	std::unique_ptr<ClusterImpl> obj(new ClusterImpl(scene, element));
 
 	const Element* transform_link = findChild(element, "TransformLink");
 	if (transform_link && transform_link->first_property)
@@ -2017,7 +2018,7 @@ template <typename T> static void remap(std::vector<T>* out, const std::vector<i
 
 static OptionalError<Object*> parseAnimationCurve(const Scene& scene, const Element& element)
 {
-	std::unique_ptr<AnimationCurveImpl> curve = std::make_unique<AnimationCurveImpl>(scene, element);
+	std::unique_ptr<AnimationCurveImpl> curve(new AnimationCurveImpl(scene, element));
 
 	const Element* times = findChild(element, "KeyTime");
 	const Element* values = findChild(element, "KeyValueFloat");
@@ -2087,7 +2088,7 @@ static OptionalError<Object*> parseGeometry(const Scene& scene, const Element& e
 	const Element* polys_element = findChild(element, "PolygonVertexIndex");
 	if (!polys_element || !polys_element->first_property) return Error("Indices missing");
 
-	std::unique_ptr<GeometryImpl> geom = std::make_unique<GeometryImpl>(scene, element);
+	std::unique_ptr<GeometryImpl> geom(new GeometryImpl(scene, element));
 
 	std::vector<Vec3> vertices;
 	if (!parseDoubleVecData(*vertices_element->first_property, &vertices)) return Error("Failed to parse vertices");
@@ -2917,7 +2918,7 @@ Object* Object::getParent() const
 
 IScene* load(const u8* data, int size)
 {
-	std::unique_ptr<Scene> scene = std::make_unique<Scene>();
+	std::unique_ptr<Scene> scene(new Scene());
 	scene->m_data.resize(size);
 	memcpy(&scene->m_data[0], data, size);
 	OptionalError<Element*> root = tokenize(&scene->m_data[0], size);


### PR DESCRIPTION
Simply converted all the

prop = std::make_unique<Property>();

into the equivalent, shorter and more c++11 compatible

prop(new Property());