### PR TITLE
Handle 'Line' property type for Geometry and Model

### DIFF
--- a/src/ofbx.cpp
+++ b/src/ofbx.cpp
@@ -2470,6 +2470,10 @@ static bool parseObjects(const Element& root, Scene* scene)
 			{
 				obj = parseGeometry(*scene, *iter.second.element);
 			}
+			else if (last_prop && last_prop->value == "Line")
+			{
+				obj = parseGeometry(*scene, *iter.second.element);
+			}
 		}
 		else if (iter.second.element->id == "Material")
 		{
@@ -2530,6 +2534,8 @@ static bool parseObjects(const Element& root, Scene* scene)
 				}
 				else if (class_prop->getValue() == "LimbNode")
 					obj = parseLimbNode(*scene, *iter.second.element);
+				else if (class_prop->getValue() == "Line")
+					obj = parse<NullImpl>(*scene, *iter.second.element);
 				else if (class_prop->getValue() == "Null")
 					obj = parse<NullImpl>(*scene, *iter.second.element);
 				else if (class_prop->getValue() == "Root")


### PR DESCRIPTION
A model I was testing was missing parts of its transform hierarchy, I found some objects were getting ignored because they had a "Line" property which wasn't being handled. 

It works correctly with these changes, I'm not sure if the "Line" type has other data in it but I only needed it for the transform.

Thanks! And nice work with OpenFBX, it's working great.