### PR TITLE
Bunch of improvements

### DIFF
--- a/src/ofbx.cpp
+++ b/src/ofbx.cpp
@@ -1396,6 +1396,7 @@ struct Scene : IScene
 	int getAnimationStackCount() const override { return (int)m_animation_stacks.size(); }
 	int getMeshCount() const override { return (int)m_meshes.size(); }
 	float getSceneFrameRate() const override { return m_scene_frame_rate; }
+	const GlobalSettings* getGlobalSettings() const override { return &m_settings; }
 
 	const Object* const* getAllObjects() const override { return m_all_objects.empty() ? nullptr : &m_all_objects[0]; }
 
@@ -1450,6 +1451,7 @@ struct Scene : IScene
 	Element* m_root_element = nullptr;
 	Root* m_root = nullptr;
 	float m_scene_frame_rate = -1;
+	GlobalSettings m_settings;
 	std::unordered_map<u64, ObjectPair> m_object_map;
 	std::vector<Object*> m_all_objects;
 	std::vector<Mesh*> m_meshes;
@@ -2350,28 +2352,7 @@ static bool parseTakes(Scene* scene)
 }
 
 
-// http://docs.autodesk.com/FBX/2014/ENU/FBX-SDK-Documentation/index.html?url=cpp_ref/class_fbx_time.html,topicNumber=cpp_ref_class_fbx_time_html29087af6-8c2c-4e9d-aede-7dc5a1c2436c,hash=a837590fd5310ff5df56ffcf7c394787e
-enum FrameRate 
-{
-	FrameRate_DEFAULT = 0,
-	FrameRate_120 = 1,
-	FrameRate_100 = 2,
-	FrameRate_60 = 3,
-	FrameRate_50 = 4,
-	FrameRate_48 = 5,
-	FrameRate_30 = 6,
-	FrameRate_30_DROP = 7,
-	FrameRate_NTSC_DROP_FRAME = 8,
-	FrameRate_NTSC_FULL_FRAME = 9,
-	FrameRate_PAL = 10,
-	FrameRate_CINEMA = 11,
-	FrameRate_1000 = 12,
-	FrameRate_CINEMA_ND = 13,
-	FrameRate_CUSTOM = 14,
-};
-
-
-static float getFramerateFromTimeMode(int time_mode)
+static float getFramerateFromTimeMode(FrameRate time_mode, float custom_frame_rate)
 {
 	switch (time_mode)
 	{
@@ -2389,7 +2370,7 @@ static float getFramerateFromTimeMode(int time_mode)
 		case FrameRate_CINEMA: return 24;
 		case FrameRate_1000: return 1000;
 		case FrameRate_CINEMA_ND: return 23.976f;
-		case FrameRate_CUSTOM: return -2;
+		case FrameRate_CUSTOM: return custom_frame_rate;
 	}
 	return -1;
 }
@@ -2405,19 +2386,39 @@ static void parseGlobalSettings(const Element& root, Scene* scene)
 			{
 				if (props70->id == "Properties70")
 				{
-					for (ofbx::Element* time_mode = props70->child; time_mode; time_mode = time_mode->sibling)
+					for (ofbx::Element* node = props70->child; node; node = node->sibling)
 					{
-						if (time_mode->first_property && time_mode->first_property->value == "TimeMode")
-						{
-							ofbx::IElementProperty* prop = time_mode->getProperty(4);
-							if (prop)
-							{
-								ofbx::DataView value = prop->getValue();
-								int time_mode = *(int*)value.begin;
-								scene->m_scene_frame_rate = getFramerateFromTimeMode(time_mode);
-							}
-							break;
+						if (!node->first_property)
+							continue;
+
+#define get_property(name, field, type) if(node->first_property->value == name) \
+						{ \
+							ofbx::IElementProperty* prop = node->getProperty(4); \
+							if (prop) \
+							{ \
+								ofbx::DataView value = prop->getValue(); \
+								scene->m_settings.field = *(type*)value.begin; \
+							} \
 						}
+
+						get_property("UpAxis", UpAxis, UpVector);
+						get_property("UpAxisSign", UpAxisSign, int);
+						get_property("FrontAxis", FrontAxis, FrontVector);
+						get_property("FrontAxisSign", FrontAxisSign, int);
+						get_property("CoordAxis", CoordAxis, CoordSystem);
+						get_property("CoordAxisSign", CoordAxisSign, int);
+						get_property("OriginalUpAxis", OriginalUpAxis, int);
+						get_property("OriginalUpAxisSign", OriginalUpAxisSign, int);
+						get_property("UnitScaleFactor", UnitScaleFactor, float);
+						get_property("OriginalUnitScaleFactor", OriginalUnitScaleFactor, float);
+						get_property("TimeSpanStart", TimeSpanStart, u64);
+						get_property("TimeSpanStop", TimeSpanStop, u64);
+						get_property("TimeMode", TimeMode, FrameRate);
+						get_property("CustomFrameRate", CustomFrameRate, float);
+
+#undef get_property
+
+						scene->m_scene_frame_rate = getFramerateFromTimeMode(scene->m_settings.TimeMode, scene->m_settings.CustomFrameRate);
 					}
 					break;
 				}

--- a/src/ofbx.cpp
+++ b/src/ofbx.cpp
@@ -2391,30 +2391,30 @@ static void parseGlobalSettings(const Element& root, Scene* scene)
 						if (!node->first_property)
 							continue;
 
-#define get_property(name, field, type) if(node->first_property->value == name) \
+#define get_property(name, field, type, getter) if(node->first_property->value == name) \
 						{ \
 							ofbx::IElementProperty* prop = node->getProperty(4); \
 							if (prop) \
 							{ \
 								ofbx::DataView value = prop->getValue(); \
-								scene->m_settings.field = *(type*)value.begin; \
+								scene->m_settings.field = (type)value.getter(); \
 							} \
 						}
 
-						get_property("UpAxis", UpAxis, UpVector);
-						get_property("UpAxisSign", UpAxisSign, int);
-						get_property("FrontAxis", FrontAxis, FrontVector);
-						get_property("FrontAxisSign", FrontAxisSign, int);
-						get_property("CoordAxis", CoordAxis, CoordSystem);
-						get_property("CoordAxisSign", CoordAxisSign, int);
-						get_property("OriginalUpAxis", OriginalUpAxis, int);
-						get_property("OriginalUpAxisSign", OriginalUpAxisSign, int);
-						get_property("UnitScaleFactor", UnitScaleFactor, float);
-						get_property("OriginalUnitScaleFactor", OriginalUnitScaleFactor, float);
-						get_property("TimeSpanStart", TimeSpanStart, u64);
-						get_property("TimeSpanStop", TimeSpanStop, u64);
-						get_property("TimeMode", TimeMode, FrameRate);
-						get_property("CustomFrameRate", CustomFrameRate, float);
+						get_property("UpAxis", UpAxis, UpVector, toInt);
+						get_property("UpAxisSign", UpAxisSign, int, toInt);
+						get_property("FrontAxis", FrontAxis, FrontVector, toInt);
+						get_property("FrontAxisSign", FrontAxisSign, int, toInt);
+						get_property("CoordAxis", CoordAxis, CoordSystem, toInt);
+						get_property("CoordAxisSign", CoordAxisSign, int, toInt);
+						get_property("OriginalUpAxis", OriginalUpAxis, int, toInt);
+						get_property("OriginalUpAxisSign", OriginalUpAxisSign, int, toInt);
+						get_property("UnitScaleFactor", UnitScaleFactor, float, toDouble);
+						get_property("OriginalUnitScaleFactor", OriginalUnitScaleFactor, float, toDouble);
+						get_property("TimeSpanStart", TimeSpanStart, u64, toU64);
+						get_property("TimeSpanStop", TimeSpanStop, u64, toU64);
+						get_property("TimeMode", TimeMode, FrameRate, toInt);
+						get_property("CustomFrameRate", CustomFrameRate, float, toDouble);
 
 #undef get_property
 

--- a/src/ofbx.cpp
+++ b/src/ofbx.cpp
@@ -2159,7 +2159,7 @@ static OptionalError<Object*> parseGeometry(const Scene& scene, const Element& e
             std::vector<int> tmp_indices;
             GeometryImpl::VertexDataMapping mapping;
             if (!parseVertexData(*layer_uv_element, "UV", "UVIndex", &tmp, &tmp_indices, &mapping)) return Error("Invalid UVs");
-            if (!tmp.empty())
+			if (!tmp.empty() && tmp_indices[0] != -1)
             {
                 uvs.resize(tmp_indices.empty() ? tmp.size() : tmp_indices.size());
                 splat(&uvs, mapping, tmp, tmp_indices, original_indices);
@@ -2643,7 +2643,7 @@ static bool parseObjects(const Element& root, Scene* scene)
 				ClusterImpl* cluster = (ClusterImpl*)parent;
 				if (child->getType() == Object::Type::LIMB_NODE || child->getType() == Object::Type::MESH || child->getType() == Object::Type::NULL_NODE)
 				{
-					if (cluster->link)
+					if (cluster->link && cluster->link != child)
 					{
 						Error::s_message = "Invalid cluster";
 						return false;

--- a/src/ofbx.cpp
+++ b/src/ofbx.cpp
@@ -2622,6 +2622,7 @@ static bool parseObjects(const Element& root, Scene* scene)
 
 					if (mat->textures[type])
 					{
+						break;// This may happen for some models (eg. 2 normal maps in use)
 						Error::s_message = "Invalid material";
 						return false;
 					}

--- a/src/ofbx.cpp
+++ b/src/ofbx.cpp
@@ -2722,7 +2722,12 @@ Vec3 Object::getScalingPivot() const
 
 Matrix Object::evalLocal(const Vec3& translation, const Vec3& rotation) const
 {
-	Vec3 scaling = getLocalScaling();
+	return evalLocal(translation, rotation, getLocalScaling());
+}
+
+
+Matrix Object::evalLocal(const Vec3& translation, const Vec3& rotation, const Vec3& scaling) const
+{
 	Vec3 rotation_pivot = getRotationPivot();
 	Vec3 scaling_pivot = getScalingPivot();
 	RotationOrder rotation_order = getRotationOrder();
@@ -2792,6 +2797,12 @@ Matrix Object::getGlobalTransform() const
 	if (!parent) return evalLocal(getLocalTranslation(), getLocalRotation());
 
 	return parent->getGlobalTransform() * evalLocal(getLocalTranslation(), getLocalRotation());
+}
+
+
+Matrix Object::getLocalTransform() const
+{
+    return evalLocal(getLocalTranslation(), getLocalRotation(), getLocalScaling());
 }
 
 

--- a/src/ofbx.cpp
+++ b/src/ofbx.cpp
@@ -2160,7 +2160,7 @@ static OptionalError<Object*> parseGeometry(const Scene& scene, const Element& e
             std::vector<int> tmp_indices;
             GeometryImpl::VertexDataMapping mapping;
             if (!parseVertexData(*layer_uv_element, "UV", "UVIndex", &tmp, &tmp_indices, &mapping)) return Error("Invalid UVs");
-			if (!tmp.empty() && tmp_indices[0] != -1)
+			if (!tmp.empty() && (tmp_indices.empty() || tmp_indices[0] != -1))
             {
                 uvs.resize(tmp_indices.empty() ? tmp.size() : tmp_indices.size());
                 splat(&uvs, mapping, tmp, tmp_indices, original_indices);

--- a/src/ofbx.h
+++ b/src/ofbx.h
@@ -176,7 +176,9 @@ struct Object
 	Vec3 getLocalRotation() const;
 	Vec3 getLocalScaling() const;
 	Matrix getGlobalTransform() const;
+	Matrix getLocalTransform() const;
 	Matrix evalLocal(const Vec3& translation, const Vec3& rotation) const;
+	Matrix evalLocal(const Vec3& translation, const Vec3& rotation, const Vec3& scaling) const;
 	bool isNode() const { return is_node; }
 
 

--- a/src/ofbx.h
+++ b/src/ofbx.h
@@ -265,6 +265,7 @@ struct NodeAttribute : Object
 struct Geometry : Object
 {
 	static const Type s_type = Type::GEOMETRY;
+    static const int s_uvs_max = 4;
 
 	Geometry(const Scene& _scene, const IElement& _element);
 
@@ -272,7 +273,7 @@ struct Geometry : Object
 	virtual int getVertexCount() const = 0;
 
 	virtual const Vec3* getNormals() const = 0;
-	virtual const Vec2* getUVs() const = 0;
+	virtual const Vec2* getUVs(int index = 0) const = 0;
 	virtual const Vec4* getColors() const = 0;
 	virtual const Vec3* getTangents() const = 0;
 	virtual const Skin* getSkin() const = 0;

--- a/src/ofbx.h
+++ b/src/ofbx.h
@@ -354,6 +354,71 @@ struct TakeInfo
 };
 
 
+// Specifies which canonical axis represents up in the system (typically Y or Z).
+enum UpVector
+{
+	UpVector_AxisX = 1,
+	UpVector_AxisY = 2,
+	UpVector_AxisZ = 3
+};
+
+
+// Vector with origin at the screen pointing toward the camera.
+enum FrontVector
+{
+	FrontVector_ParityEven = 1,
+	FrontVector_ParityOdd = 2
+};
+
+
+// Specifies the third vector of the system.
+enum CoordSystem
+{
+	CoordSystem_RightHanded = 0,
+	CoordSystem_LeftHanded = 1
+};
+
+
+// http://docs.autodesk.com/FBX/2014/ENU/FBX-SDK-Documentation/index.html?url=cpp_ref/class_fbx_time.html,topicNumber=cpp_ref_class_fbx_time_html29087af6-8c2c-4e9d-aede-7dc5a1c2436c,hash=a837590fd5310ff5df56ffcf7c394787e
+enum FrameRate
+{
+	FrameRate_DEFAULT = 0,
+	FrameRate_120 = 1,
+	FrameRate_100 = 2,
+	FrameRate_60 = 3,
+	FrameRate_50 = 4,
+	FrameRate_48 = 5,
+	FrameRate_30 = 6,
+	FrameRate_30_DROP = 7,
+	FrameRate_NTSC_DROP_FRAME = 8,
+	FrameRate_NTSC_FULL_FRAME = 9,
+	FrameRate_PAL = 10,
+	FrameRate_CINEMA = 11,
+	FrameRate_1000 = 12,
+	FrameRate_CINEMA_ND = 13,
+	FrameRate_CUSTOM = 14,
+};
+
+
+struct GlobalSettings
+{
+	UpVector UpAxis = UpVector_AxisX;
+	int UpAxisSign = 1;
+	FrontVector FrontAxis = FrontVector_ParityOdd;
+	int FrontAxisSign = 1;
+	CoordSystem CoordAxis = CoordSystem_RightHanded;
+	int CoordAxisSign = 1;
+	int OriginalUpAxis = 0;
+	int OriginalUpAxisSign = 1;
+	float UnitScaleFactor = 1;
+	float OriginalUnitScaleFactor = 1;
+	u64 TimeSpanStart = 0L;
+	u64 TimeSpanStop = 0L;
+	FrameRate TimeMode = FrameRate_DEFAULT;
+	float CustomFrameRate = -1.0f;
+};
+
+
 struct IScene
 {
 	virtual void destroy() = 0;
@@ -362,6 +427,7 @@ struct IScene
 	virtual const TakeInfo* getTakeInfo(const char* name) const = 0;
 	virtual int getMeshCount() const = 0;
 	virtual float getSceneFrameRate() const = 0;
+	virtual const GlobalSettings* getGlobalSettings() const = 0;
 	virtual const Mesh* getMesh(int index) const = 0;
 	virtual int getAnimationStackCount() const = 0;
 	virtual const AnimationStack* getAnimationStack(int index) const = 0;


### PR DESCRIPTION
Changes:
* Add checking FBX version (min ver 6.2 is supported - loading older formats doesn't work in general)
* Add using proper getter for reading general FBX settings
* Fix rare crash when parsing vertex data (related to `tmp_indices`)
* Fix invalid cluster issue if it has valid link