### PR TITLE
Make mesh triangulation optional

### DIFF
--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -228,7 +228,7 @@ bool saveAsOBJ(ofbx::IScene& scene, const char* path)
 		if (has_normals)
 		{
 			const ofbx::Vec3* normals = geom.getNormals();
-			int count = geom.getVertexCount();
+			int count = geom.getIndexCount();
 
 			for (int i = 0; i < count; ++i)
 			{
@@ -241,7 +241,7 @@ bool saveAsOBJ(ofbx::IScene& scene, const char* path)
 		if (has_uvs)
 		{
 			const ofbx::Vec2* uvs = geom.getUVs();
-			int count = geom.getVertexCount();
+			int count = geom.getIndexCount();
 
 			for (int i = 0; i < count; ++i)
 			{
@@ -251,9 +251,9 @@ bool saveAsOBJ(ofbx::IScene& scene, const char* path)
 		}
 
 		const int* faceIndices = geom.getFaceIndices();
-		int indexCount = geom.getIndexCount();
+		int index_count = geom.getIndexCount();
 		bool new_face = true;
-		for (int i = 0; i < indexCount; ++i)
+		for (int i = 0; i < index_count; ++i)
 		{
 			if (new_face)
 			{
@@ -266,7 +266,8 @@ bool saveAsOBJ(ofbx::IScene& scene, const char* path)
 
 			if (has_uvs)
 			{
-				fprintf(fp, "/%d", idx);
+				int uv_idx = normals_offset + i + 1;
+				fprintf(fp, "/%d", uv_idx);
 			}
 			else
 			{
@@ -275,7 +276,8 @@ bool saveAsOBJ(ofbx::IScene& scene, const char* path)
 
 			if (has_normals)
 			{
-				fprintf(fp, "/%d", idx);
+				int normal_idx = normals_offset + i + 1;
+				fprintf(fp, "/%d", normal_idx);
 			}
 			else
 			{
@@ -287,6 +289,7 @@ bool saveAsOBJ(ofbx::IScene& scene, const char* path)
 		}
 
 		indices_offset += vertex_count;
+		normals_offset += index_count;
 		++obj_idx;
 	}
 	fclose(fp);

--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -250,16 +250,17 @@ bool saveAsOBJ(ofbx::IScene& scene, const char* path)
 			}
 		}
 
+		const int* faceIndices = geom.getFaceIndices();
+		int indexCount = geom.getIndexCount();
 		bool new_face = true;
-		int count = geom.getVertexCount();
-		for (int i = 0; i < count; ++i)
+		for (int i = 0; i < indexCount; ++i)
 		{
 			if (new_face)
 			{
 				fputs("f ", fp);
 				new_face = false;
 			}
-			int idx = i + 1;
+			int idx = (faceIndices[i] < 0) ? -faceIndices[i] : (faceIndices[i] + 1);
 			int vertex_idx = indices_offset + idx;
 			fprintf(fp, "%d", vertex_idx);
 
@@ -281,7 +282,7 @@ bool saveAsOBJ(ofbx::IScene& scene, const char* path)
 				fprintf(fp, "/");
 			}
 
-			new_face = idx % 3 == 0;
+			new_face = faceIndices[i] < 0;
 			fputc(new_face ? '\n' : ' ', fp);
 		}
 

--- a/src/ofbx.cpp
+++ b/src/ofbx.cpp
@@ -1910,6 +1910,18 @@ static bool parseVertexData(const Element& element,
 }
 
 
+static int decodeIndex(int idx)
+{
+	return (idx < 0) ? (-idx - 1) : idx;
+}
+
+
+static int codeIndex(int idx, bool last)
+{
+	return last ? (-idx - 1) : idx;
+}
+
+
 template <typename T>
 static void splat(std::vector<T>* out,
 	GeometryImpl::VertexDataMapping mapping,
@@ -1951,8 +1963,7 @@ static void splat(std::vector<T>* out,
 		int data_size = (int)data.size();
 		for (int i = 0, c = (int)original_indices.size(); i < c; ++i)
 		{
-			int idx = original_indices[i];
-			if (idx < 0) idx = -idx - 1;
+			int idx = decodeIndex(original_indices[i]);
 			if (idx < data_size)
 				(*out)[i] = data[idx];
 			else
@@ -2042,18 +2053,6 @@ static void add(GeometryImpl::NewVertex& vtx, int index)
 		vtx.next = new GeometryImpl::NewVertex;
 		vtx.next->index = index;
 	}
-}
-
-
-int decodeIndex(int idx)
-{
-	return (idx < 0) ? (-idx - 1) : idx;
-}
-
-
-int codeIndex(int idx, bool last)
-{
-	return last ? (-idx - 1) : idx;
 }
 
 

--- a/src/ofbx.h
+++ b/src/ofbx.h
@@ -443,7 +443,7 @@ protected:
 };
 
 
-IScene* load(const u8* data, int size);
+IScene* load(const u8* data, int size, bool triangulate = true);
 const char* getError();
 
 

--- a/src/ofbx.h
+++ b/src/ofbx.h
@@ -279,6 +279,9 @@ struct Geometry : Object
 	virtual const Vec3* getVertices() const = 0;
 	virtual int getVertexCount() const = 0;
 
+	virtual const int* getFaceIndices() const = 0;
+	virtual int getIndexCount() const = 0;
+
 	virtual const Vec3* getNormals() const = 0;
 	virtual const Vec2* getUVs(int index = 0) const = 0;
 	virtual const Vec4* getColors() const = 0;


### PR DESCRIPTION
- Refactor geometry parsing and construction.
- Add face indices to `Geometry` interface.
- Make mesh triangulation optional.

When mesh triangulation is enabled (default case) face indices may be ignored. So this patch doesn't require any changes in client code.