### PR TITLE
Some basic static analysis fixes

### DIFF
--- a/src/ofbx.h
+++ b/src/ofbx.h
@@ -120,6 +120,7 @@ struct IElementProperty
 
 struct IElement
 {
+	virtual ~IElement() = default;
 	virtual IElement* getFirstChild() const = 0;
 	virtual IElement* getSibling() const = 0;
 	virtual DataView getID() const = 0;


### PR DESCRIPTION
- proper return type (bool instead of int)
- declare destructors "override" where applicable
- ensure data is initialized
- fix order of constructor initialization
- remove unused variables