### PR TITLE
Add basic Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+dist: xenial
+sudo: false
+language: cpp
+
+env:
+  matrix:
+    - BUILD_TYPE=Debug
+    - BUILD_TYPE=Release
+
+compiler:
+  - clang
+  - gcc
+
+before_script:
+  - cd ci
+  - mkdir build-${BUILD_TYPE}
+  - cd build-${BUILD_TYPE}
+  - cmake -DCMAKE_BUILD_TYPE=${BUILD_TYPE} ..
+
+script:
+  - $CC_FOR_BUILD -v && $CXX_FOR_BUILD -v && cmake --version
+  - make -j2

--- a/ci/CMakeLists.txt
+++ b/ci/CMakeLists.txt
@@ -1,0 +1,21 @@
+
+cmake_minimum_required( VERSION 3.8 FATAL_ERROR )
+
+project( OpenFBX_Test
+  LANGUAGES C CXX
+)
+
+add_executable( OpenFBX_Test
+  ../src/miniz.h
+  ../src/miniz.c
+  ../src/ofbx.h
+  ../src/ofbx.cpp
+  main.cpp
+)
+
+target_compile_features( OpenFBX_Test PRIVATE cxx_std_11 )
+
+target_include_directories( OpenFBX_Test
+    PUBLIC
+    ../src
+)

--- a/ci/main.cpp
+++ b/ci/main.cpp
@@ -1,0 +1,4 @@
+int  main( int argc, char **argv )
+{
+   return 0;
+}


### PR DESCRIPTION
Adds basic Travis CI for OpenFBX.

This will compile the library into an executable (with an empty `main()`) in release and debug on gcc and clang.

**Before merging**, log into https://travis-ci.org and turn on CI for this repo so it will run on every PR and commit.

In the future, this would also be a good place to run automated tests.