### PR TITLE
fix error when loading from text mode fbx files.

### DIFF
--- a/src/ofbx.cpp
+++ b/src/ofbx.cpp
@@ -2156,7 +2156,7 @@ template <> const char* fromString<Matrix>(const char* str, const char* end, Mat
 template <typename T> static void parseTextArray(const Property& property, std::vector<T>* out)
 {
 	const u8* iter = property.value.begin;
-	for (int i = 0; i < property.count; ++i)
+	while (iter < property.value.end)
 	{
 		T val;
 		iter = (const u8*)fromString<T>((const char*)iter, (const char*)property.value.end, &val);


### PR DESCRIPTION
this should be a copy&paste error. Cause blend shape import error from text format files.