### PR TITLE
Fix build on 32-bit archs

### DIFF
--- a/src/ofbx.h
+++ b/src/ofbx.h
@@ -1,26 +1,21 @@
 #pragma once
 
+#include <cstdint>
 
 namespace ofbx
 {
 
 
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-#ifdef _WIN32
-	typedef long long i64;
-	typedef unsigned long long u64;
-#else
-	typedef long i64;
-	typedef unsigned long u64;
-#endif
+typedef uint8_t u8;
+typedef uint16_t u16;
+typedef uint32_t u32;
+typedef int64_t i64;
+typedef uint64_t u64;
 
 static_assert(sizeof(u8) == 1, "u8 is not 1 byte");
 static_assert(sizeof(u32) == 4, "u32 is not 4 bytes");
 static_assert(sizeof(u64) == 8, "u64 is not 8 bytes");
 static_assert(sizeof(i64) == 8, "i64 is not 8 bytes");
-
 
 using JobFunction = void (*)(void*);
 using JobProcessor = void (*)(JobFunction, void*, void*, u32, u32);


### PR DESCRIPTION
The typedefs for the 64bit vars are not correct on 32 bit archs, triggering the
static asserts. Intead use C++11 standard types.

(Argubably, a global s/u64/uint64_t/g reps a s/i64/int64_t/g would do the job as well,
but this patch would be much more intrusive).

Note: uintXX_t is a C++11 feature, this might (did not check) bump the language standard
requirments.)

Example problem caused by this is the build error on darkradiant for Debian, see
 https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1001110
An example build log can be found here: https://buildd.debian.org/status/fetch.php?pkg=darkradiant&arch=i386&ver=2.14.0-1&stamp=1638612147&raw=0