### PR TITLE
Fix missing output clear when reading text array

### DIFF
--- a/src/ofbx.cpp
+++ b/src/ofbx.cpp
@@ -2155,6 +2155,7 @@ template <> const char* fromString<Matrix>(const char* str, const char* end, Mat
 
 template <typename T> static void parseTextArray(const Property& property, std::vector<T>* out)
 {
+	out->clear();
 	const u8* iter = property.value.begin;
 	while (iter < property.value.end)
 	{


### PR DESCRIPTION
If an ASCII FBX file has both tangents and normals in it, then currently the parsed geometry normals wrongly contain tangent data. This seems to be caused by nothing ever clearing `tmp->v3` array, so while parsing the file first the tangents are written into it, and then the normals appended at the end.