### PR TITLE
Fix a bug in patchAttributes function

### DIFF
--- a/src/ofbx.cpp
+++ b/src/ofbx.cpp
@@ -1164,6 +1164,7 @@ struct GeometryDataImpl : GeometryData {
 		T res = attr;
 		if (!attr.values.empty() && attr.mapping == VertexDataMapping::BY_VERTEX && attr.indices.empty()) {
 			res.indices = positions.indices.data();
+			res.count = int(positions.indices.size());
 		}
 		return res;
 	}


### PR DESCRIPTION
This bug led to a load of incorrect normal vectors in some files exported from Maya.