### PR TITLE
Replace miniz dependency with libdeflate in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,10 +6,10 @@ set(CMAKE_CXX_STANDARD 11)
 
 include(GNUInstallDirs)
 
-find_package(miniz REQUIRED)
+find_package(libdeflate REQUIRED)
 
 add_library(OpenFBX src/ofbx.cpp)
-target_link_libraries(OpenFBX PRIVATE miniz::miniz)
+target_link_libraries(OpenFBX PRIVATE libdeflate::libdeflate_static)
 
 target_include_directories(OpenFBX
         PUBLIC

--- a/openfbxConfig.cmake.in
+++ b/openfbxConfig.cmake.in
@@ -1,8 +1,8 @@
 @PACKAGE_INIT@
 
 include(CMakeFindDependencyMacro)
-find_dependency(miniz)
+find_dependency(libdeflate)
 
 include("${CMAKE_CURRENT_LIST_DIR}/openfbxTargets.cmake")
 
-check_required_components(miniz)
+check_required_components(libdeflate)


### PR DESCRIPTION
miniz was replaced with libdeflate in https://github.com/nem0/OpenFBX/commit/7f64c109fd54d51d6c7ec698456c7a12e762ea50