### PR TITLE
Load function: change size parameter type from int to usize

### DIFF
--- a/src/ofbx.cpp
+++ b/src/ofbx.cpp
@@ -4046,7 +4046,7 @@ bool Scene::finalize() {
 	return true;
 }
 
-IScene* load(const u8* data, u64 size, u16 flags, JobProcessor job_processor, void* job_user_ptr)
+IScene* load(const u8* data, usize size, u16 flags, JobProcessor job_processor, void* job_user_ptr)
 {
 	std::unique_ptr<Scene> scene(new Scene());
 	scene->m_data.resize(size);

--- a/src/ofbx.cpp
+++ b/src/ofbx.cpp
@@ -4046,7 +4046,7 @@ bool Scene::finalize() {
 	return true;
 }
 
-IScene* load(const u8* data, size_t size, u16 flags, JobProcessor job_processor, void* job_user_ptr)
+IScene* load(const u8* data, u64 size, u16 flags, JobProcessor job_processor, void* job_user_ptr)
 {
 	std::unique_ptr<Scene> scene(new Scene());
 	scene->m_data.resize(size);

--- a/src/ofbx.cpp
+++ b/src/ofbx.cpp
@@ -4046,7 +4046,7 @@ bool Scene::finalize() {
 	return true;
 }
 
-IScene* load(const u8* data, int size, u16 flags, JobProcessor job_processor, void* job_user_ptr)
+IScene* load(const u8* data, size_t size, u16 flags, JobProcessor job_processor, void* job_user_ptr)
 {
 	std::unique_ptr<Scene> scene(new Scene());
 	scene->m_data.resize(size);

--- a/src/ofbx.h
+++ b/src/ofbx.h
@@ -756,7 +756,7 @@ protected:
 };
 
 
-IScene* load(const u8* data, int size, u16 flags, JobProcessor job_processor = nullptr, void* job_user_ptr = nullptr);
+IScene* load(const u8* data, size_t size, u16 flags, JobProcessor job_processor = nullptr, void* job_user_ptr = nullptr);
 const char* getError();
 double fbxTimeToSeconds(i64 value);
 i64 secondsToFbxTime(double value);

--- a/src/ofbx.h
+++ b/src/ofbx.h
@@ -21,6 +21,7 @@ static_assert(sizeof(u32) == 4, "u32 is not 4 bytes");
 static_assert(sizeof(u64) == 8, "u64 is not 8 bytes");
 static_assert(sizeof(i64) == 8, "i64 is not 8 bytes");
 
+typedef decltype(sizeof(0)) usize;
 
 using JobFunction = void (*)(void*);
 using JobProcessor = void (*)(JobFunction, void*, void*, u32, u32);
@@ -756,7 +757,7 @@ protected:
 };
 
 
-IScene* load(const u8* data, u64 size, u16 flags, JobProcessor job_processor = nullptr, void* job_user_ptr = nullptr);
+IScene* load(const u8* data, usize size, u16 flags, JobProcessor job_processor = nullptr, void* job_user_ptr = nullptr);
 const char* getError();
 double fbxTimeToSeconds(i64 value);
 i64 secondsToFbxTime(double value);

--- a/src/ofbx.h
+++ b/src/ofbx.h
@@ -756,7 +756,7 @@ protected:
 };
 
 
-IScene* load(const u8* data, size_t size, u16 flags, JobProcessor job_processor = nullptr, void* job_user_ptr = nullptr);
+IScene* load(const u8* data, u64 size, u16 flags, JobProcessor job_processor = nullptr, void* job_user_ptr = nullptr);
 const char* getError();
 double fbxTimeToSeconds(i64 value);
 i64 secondsToFbxTime(double value);


### PR DESCRIPTION
While internal functions, like `tokenize()` and `tokenizeText()` already used the correct size type, the main `load()` function used `int` as size type. This restricts the size of supported FBX files to 2GB.

With this small fix, larger files can be processed. I've tested this succesfully with a 3.5GB FBX file.