### PR TITLE
Fix build with Clang 12

### DIFF
--- a/src/ofbx.cpp
+++ b/src/ofbx.cpp
@@ -12,7 +12,7 @@
 #include <inttypes.h>
 #include <string.h>
 
-#if __cplusplus >= 202002L
+#if __cplusplus >= 202002L && defined(__cpp_lib_bit_cast)
 #include <bit> // for std::bit_cast (C++20 and later)
 #endif
 #include <map>
@@ -1051,7 +1051,7 @@ static OptionalError<Element*> tokenize(const u8* data, size_t size, u32& versio
 	cursor.current = data;
 	cursor.end = data + size;
 
-#if __cplusplus >= 202002L
+#if __cplusplus >= 202002L && defined(__cpp_lib_bit_cast)
 	const Header* header = std::bit_cast<const Header*>(cursor.current);
 #else
 	Header header_temp;


### PR DESCRIPTION
Clang12 does not support `std::bit_cast`, so this change introduces a check for the `std::bit_cast` feature using the `__cpp_lib_bit_cast` macro, according to the documentation found at https://en.cppreference.com/w/cpp/feature_test