### PR TITLE
Fix alignment issue in read()

### DIFF
--- a/src/ofbx.cpp
+++ b/src/ofbx.cpp
@@ -592,7 +592,7 @@ static bool decompress(const u8* in, size_t in_size, u8* out, size_t out_size)
 template <typename T> static OptionalError<T> read(Cursor* cursor)
 {
 	if (cursor->current + sizeof(T) > cursor->end) return Error("Reading past the end");
-	T value = *(const T*)cursor->current;
+	T value = read_value<T>(cursor->current);
 	cursor->current += sizeof(T);
 	return value;
 }


### PR DESCRIPTION
The issue stems from an oversight in https://github.com/nem0/OpenFBX/pull/96, resulting in a runtime error due to misalignment:

```
ofbx.cpp:595:12: runtime error: load of misaligned address 0x7fdf1b93581b for type 'const unsigned long', which requires 8 byte alignment
```