### PR TITLE
Fix i64 and u64 typedef for emscripten builds

### DIFF
--- a/src/ofbx.h
+++ b/src/ofbx.h
@@ -8,7 +8,7 @@ namespace ofbx
 typedef unsigned char u8;
 typedef unsigned short u16;
 typedef unsigned int u32;
-#if defined(_WIN32) || defined(__ANDROID__)
+#if defined(_WIN32) || defined(__ANDROID__) || defined(__EMSCRIPTEN__)
 	typedef long long i64;
 	typedef unsigned long long u64;
 #else


### PR DESCRIPTION
Got an error when trying to build my engine for web. Adding these typedefs fixed the issue.